### PR TITLE
[MAINTENANCE] Fix publish workflow - install protobuf compiler

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
Fix the publish workflow to install the protobuf compiler which is required by `prost-build`.

## Problem
The publish workflow failed with:
```
Error: Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable to the path of the `protoc` binary.
```

## Solution
Added a step to install `protobuf-compiler` on Ubuntu before running tests and publishing.

## Testing
This will be tested when we re-push the v0.2.0 tag after merging this PR.