### PR TITLE
[BUG] #48 - Fix uncompressed PBF file reading (Fixes #39)

### DIFF
--- a/src/osm/pbf/file_block.rs
+++ b/src/osm/pbf/file_block.rs
@@ -119,11 +119,9 @@ impl FileBlock {
             }
             Some(data) => {
                 match data {
-                    Data::Raw(_) => {
-                        Err(
-                            // TODO:
-                            anyhow!("Raw data type not implemented")
-                        )
+                    Data::Raw(raw_data) => {
+                        // Uncompressed data - return as-is
+                        Ok(raw_data)
                     }
                     Data::ZlibData(zlib_data) => {
                         // for now ignore that the uncompressed size is optional

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,6 +19,7 @@ pub fn setup() {
     }
 }
 
+#[allow(dead_code)]
 pub fn read_fixture_analysis(path: &PathBuf) -> JsonValue {
     let fixture_analysis_string = fs::read_to_string(path)
         .with_context(|| format!("path: {}", path.to_string_lossy()))
@@ -28,6 +29,7 @@ pub fn read_fixture_analysis(path: &PathBuf) -> JsonValue {
     fixture_analysis
 }
 
+#[allow(dead_code)]
 pub fn analyze_pbf_output(output_path: PathBuf, fixture_analysis_path: PathBuf) {
     let fixture_analysis = read_fixture_analysis(&fixture_analysis_path);
     let test_reader = Reader::new(&output_path).unwrap();

--- a/tests/test_uncompressed_pbf_rw.rs
+++ b/tests/test_uncompressed_pbf_rw.rs
@@ -1,0 +1,103 @@
+mod common;
+
+use std::path::PathBuf;
+use osm_io::osm::model::element::Element;
+use osm_io::osm::pbf;
+use osm_io::osm::pbf::compression_type::CompressionType;
+use osm_io::osm::pbf::file_info::FileInfo;
+
+#[test]
+fn test_uncompressed_pbf_read_write() {
+    common::setup();
+
+    let input_path = PathBuf::from("./tests/fixtures/niue-230109.osm.pbf");
+    let output_path = PathBuf::from("./target/results/test-uncompressed-output.osm.pbf");
+
+    // Write uncompressed PBF file
+    let reader = pbf::reader::Reader::new(&input_path).unwrap();
+    let mut file_info = FileInfo::default();
+    file_info.with_writingprogram_str("test_uncompressed_pbf_rw");
+    let mut writer = pbf::writer::Writer::from_file_info(
+        output_path.clone(),
+        file_info,
+        CompressionType::Uncompressed,
+    ).unwrap();
+
+    writer.write_header().unwrap();
+
+    let mut written_count = 0;
+    for element in reader.elements().unwrap() {
+        writer.write_element(element).unwrap();
+        written_count += 1;
+    }
+
+    writer.close().unwrap();
+
+    // Read back the uncompressed file
+    let reader2 = pbf::reader::Reader::new(&output_path).unwrap();
+    let mut readback_count = 0;
+    for element in reader2.elements().unwrap() {
+        match element {
+            Element::Sentinel => {}
+            _ => readback_count += 1,
+        }
+    }
+
+    assert_eq!(written_count, readback_count,
+               "Element count mismatch: written {} but read back {}",
+               written_count, readback_count);
+}
+
+#[test]
+fn test_uncompressed_pbf_roundtrip() {
+    common::setup();
+
+    let input_path = PathBuf::from("./tests/fixtures/niue-230109.osm.pbf");
+    let temp_path = PathBuf::from("./target/results/test-roundtrip-temp.osm.pbf");
+
+    // First write: read compressed, write uncompressed
+    let reader1 = pbf::reader::Reader::new(&input_path).unwrap();
+    let mut file_info1 = FileInfo::default();
+    file_info1.with_writingprogram_str("test_roundtrip_step1");
+    let mut writer1 = pbf::writer::Writer::from_file_info(
+        temp_path.clone(),
+        file_info1,
+        CompressionType::Uncompressed,
+    ).unwrap();
+
+    writer1.write_header().unwrap();
+    for element in reader1.elements().unwrap() {
+        writer1.write_element(element).unwrap();
+    }
+    writer1.close().unwrap();
+
+    // Second write: read uncompressed, write uncompressed again
+    let output_path = PathBuf::from("./target/results/test-roundtrip-output.osm.pbf");
+    let reader2 = pbf::reader::Reader::new(&temp_path).unwrap();
+    let mut file_info2 = FileInfo::default();
+    file_info2.with_writingprogram_str("test_roundtrip_step2");
+    let mut writer2 = pbf::writer::Writer::from_file_info(
+        output_path.clone(),
+        file_info2,
+        CompressionType::Uncompressed,
+    ).unwrap();
+
+    writer2.write_header().unwrap();
+    let mut count2 = 0;
+    for element in reader2.elements().unwrap() {
+        writer2.write_element(element).unwrap();
+        count2 += 1;
+    }
+    writer2.close().unwrap();
+
+    // Third read: verify the final output
+    let reader3 = pbf::reader::Reader::new(&output_path).unwrap();
+    let mut count3 = 0;
+    for _element in reader3.elements().unwrap() {
+        count3 += 1;
+    }
+
+    assert_eq!(count2, count3,
+               "Roundtrip failed: step2 wrote {} but step3 read {}",
+               count2, count3);
+}


### PR DESCRIPTION
## Summary
Fixes #39 - Cannot read output file when using uncompressed PBF format

## Changes
- Implemented `Data::Raw` handling in `read_blob_data` function in `src/osm/pbf/file_block.rs`
- Uncompressed data is now returned directly without attempting decompression
- Added 2 comprehensive integration tests in `tests/test_uncompressed_pbf_rw.rs`:
  - `test_uncompressed_pbf_read_write`: Tests basic uncompressed write and read
  - `test_uncompressed_pbf_roundtrip`: Tests multiple sequential uncompressed operations
- Fixed clippy warnings in test helpers by adding `#[allow(dead_code)]` attribute

## Root Cause
The writer correctly wrote uncompressed data using `Data::Raw`, but the reader's `read_blob_data` function returned an error "Raw data type not implemented" instead of handling the uncompressed data.

## Testing
- All 23 tests pass (21 existing + 2 new)
- Zero clippy warnings
- Successfully reproduces and verifies the exact bug scenario from Issue #39

Closes #39
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)